### PR TITLE
Pass module name and AWS region to integration tests

### DIFF
--- a/CHANGELOG/0.0.2.md
+++ b/CHANGELOG/0.0.2.md
@@ -7,3 +7,4 @@
 * [#19](https://github.com/epiphany-platform/m-aws-kubernetes-service/issues/19) - Add prefix to autoscaler_name and add private_route_table_id as input variable
 * [#18](https://github.com/epiphany-platform/m-aws-kubernetes-service/issues/18) - Ability to create EKS in existing subnets
 * [#6](https://github.com/epiphany-platform/m-aws-kubernetes-service/issues/6) - Replace terraform-aws-eks module by eks_cluster resource
+* [#41](https://github.com/epiphany-platform/m-aws-kubernetes-service/issues/41) - Pass name and region parameters in pipeline

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ AwsKS module is reponsible for providing managed Kubernetes service [(Amazon EKS
 
 ## Prepare AWS access key
 
-Have a look [here](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
+Have a
+look [here](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
 
 ## Build image
 
@@ -27,7 +28,11 @@ or directly using Docker:
 
 ## Run module
 
-The AwsKS cluster and new private subnets will be created in the vpc from the [AwsBI Module](https://github.com/epiphany-platform/m-aws-basic-infrastructure) or you can create the AwsKS cluster in an already existing subnets. Amazon EKS requires subnets in at least two Availability Zones. The existing VPC must meet specific [requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) for use with Amazon EKS.
+The AwsKS cluster and new private subnets will be created in the vpc from
+the [AwsBI Module](https://github.com/epiphany-platform/m-aws-basic-infrastructure) or you can create the AwsKS cluster
+in an already existing subnets. Amazon EKS requires subnets in at least two Availability Zones. The existing VPC must
+meet specific [requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) for use with Amazon
+EKS.
 
 At this stage you should have already /tmp/shared directory with your ssh-keys and AwsBI module data.
 
@@ -37,8 +42,8 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsks:latest init
   ```
 
-  This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate what is stored in that file.
-  Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
+  This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate
+  what is stored in that file. Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
 
   Note: M_REGION and M_NAME have to be the same as in AwsBI module
 
@@ -48,7 +53,8 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsks:latest init M_REGION="region of existing VPC" M_VPC_ID="existiing vpc id" M_SUBNET_IDS="[existing_subnet1_id,existing_subnet2_id,...]"
   ```
 
-   This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate what is stored in that file. Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
+  This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate
+  what is stored in that file. Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
 
 * Plan and apply AwsKS module:
 
@@ -65,11 +71,13 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsks:latest kubeconfig
   ```
 
-  This command will create file `/tmp/shared/kubeconfig`. You will need to move this file manually to `/tmp/shared/build/your-cluster-name/kubeconfig`.
+  This command will create file `/tmp/shared/kubeconfig`. You will need to move this file manually
+  to `/tmp/shared/build/your-cluster-name/kubeconfig`.
 
 ## Run module with provided example
 
-* Prepare your own variables in vars.mk file to use in the building process. Sample file (examples/basic_flow/vars.mk.sample):
+* Prepare your own variables in vars.mk file to use in the building process. Sample file (
+  examples/basic_flow/vars.mk.sample):
 
   ```shell
   AWS_ACCESS_KEY_ID = "access key id"
@@ -87,7 +95,8 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
 
 ## Run module with provided example in existing subnets
 
-* Prepare your own variables in vars.mk file to use in the building process. Sample file (examples/create_in_existing_subnets/vars.mk.sample):
+* Prepare your own variables in vars.mk file to use in the building process. Sample file (
+  examples/create_in_existing_subnets/vars.mk.sample):
 
   ```shell
   AWS_ACCESS_KEY = "access key id"
@@ -125,15 +134,40 @@ or if you want to set different version number:
   make release VERSION=number_of_your_choice
   ```
 
+## Integration tests execution
+
+Prior to run integration tests specify environment variables:
+
+### Required environment variables
+
+- AWS_ACCESS_KEY_ID - your access key
+- AWS_SECRET_ACCESS_KEY - your secret
+- AWSBI_IMAGE_TAG - full tag of docker image that you want to test e.g. "epiphanyplatform/awsbi:0.0.1"
+- AWSKS_IMAGE_TAG - full tag of docker image that you want to test e.g. "epiphanyplatform/awsks:0.0.1"
+
+### Optional environment variables
+
+- M_NAME_PREFIX - prefix to create AWS resources with
+- M_REGION - AWS region to create resources in
+
+and after that run shell command:
+
+```shell
+  make test
+```
+
 ## Notes
 
-* The cluster autoscaler major and minor versions must match your cluster.
-For example if you are running a 1.16 EKS cluster set version to v1.16.5.
-For more details check [documentation](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/autoscaling.md#notes)
+* The cluster autoscaler major and minor versions must match your cluster. For example if you are running a 1.16 EKS
+  cluster set version to v1.16.5. For more details
+  check [documentation](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/autoscaling.md#notes)
 
 ## Windows users
 
-This module is designed for Linux/Unix development/usage only. If you need to develop from Windows you can use the included [devcontainer setup for VScode](https://code.visualstudio.com/docs/remote/containers-tutorial) and run the examples the same way but then from then ```examples/basic_flow_devcontainer``` folder or ```examples/create_in_existing_subnets_devcontainer```.
+This module is designed for Linux/Unix development/usage only. If you need to develop from Windows you can use the
+included [devcontainer setup for VScode](https://code.visualstudio.com/docs/remote/containers-tutorial) and run the
+examples the same way but then from then ```examples/basic_flow_devcontainer``` folder
+or ```examples/create_in_existing_subnets_devcontainer```.
 
 ## Module dependencies
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ AwsKS module is reponsible for providing managed Kubernetes service [(Amazon EKS
 
 ## Prepare AWS access key
 
-Have a
-look [here](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
+Have a look [here](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
 
 ## Build image
 
@@ -28,11 +27,7 @@ or directly using Docker:
 
 ## Run module
 
-The AwsKS cluster and new private subnets will be created in the vpc from
-the [AwsBI Module](https://github.com/epiphany-platform/m-aws-basic-infrastructure) or you can create the AwsKS cluster
-in an already existing subnets. Amazon EKS requires subnets in at least two Availability Zones. The existing VPC must
-meet specific [requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) for use with Amazon
-EKS.
+The AwsKS cluster and new private subnets will be created in the vpc from the [AwsBI Module](https://github.com/epiphany-platform/m-aws-basic-infrastructure) or you can create the AwsKS cluster in an already existing subnets. Amazon EKS requires subnets in at least two Availability Zones. The existing VPC must meet specific [requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) for use with Amazon EKS.
 
 At this stage you should have already /tmp/shared directory with your ssh-keys and AwsBI module data.
 
@@ -42,8 +37,8 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsks:latest init
   ```
 
-  This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate
-  what is stored in that file. Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
+  This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate what is stored in that file.
+  Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
 
   Note: M_REGION and M_NAME have to be the same as in AwsBI module
 
@@ -53,8 +48,7 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsks:latest init M_REGION="region of existing VPC" M_VPC_ID="existiing vpc id" M_SUBNET_IDS="[existing_subnet1_id,existing_subnet2_id,...]"
   ```
 
-  This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate
-  what is stored in that file. Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
+   This commad will create configuration file of AwsKS module in /tmp/shared/awsks/awsks-config.yml. You can investigate what is stored in that file. Available parameters are listed in the [inputs](docs/INPUTS.adoc) document.
 
 * Plan and apply AwsKS module:
 
@@ -71,13 +65,11 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
   docker run --rm -v /tmp/shared:/shared -t epiphanyplatform/awsks:latest kubeconfig
   ```
 
-  This command will create file `/tmp/shared/kubeconfig`. You will need to move this file manually
-  to `/tmp/shared/build/your-cluster-name/kubeconfig`.
+  This command will create file `/tmp/shared/kubeconfig`. You will need to move this file manually to `/tmp/shared/build/your-cluster-name/kubeconfig`.
 
 ## Run module with provided example
 
-* Prepare your own variables in vars.mk file to use in the building process. Sample file (
-  examples/basic_flow/vars.mk.sample):
+* Prepare your own variables in vars.mk file to use in the building process. Sample file (examples/basic_flow/vars.mk.sample):
 
   ```shell
   AWS_ACCESS_KEY_ID = "access key id"
@@ -95,8 +87,7 @@ At this stage you should have already /tmp/shared directory with your ssh-keys a
 
 ## Run module with provided example in existing subnets
 
-* Prepare your own variables in vars.mk file to use in the building process. Sample file (
-  examples/create_in_existing_subnets/vars.mk.sample):
+* Prepare your own variables in vars.mk file to use in the building process. Sample file (examples/create_in_existing_subnets/vars.mk.sample):
 
   ```shell
   AWS_ACCESS_KEY = "access key id"
@@ -136,7 +127,7 @@ or if you want to set different version number:
 
 ## Integration tests execution
 
-Prior to run integration tests specify environment variables:
+Prior to integration tests execution specify environment variables:
 
 ### Required environment variables
 
@@ -158,16 +149,13 @@ and after that run shell command:
 
 ## Notes
 
-* The cluster autoscaler major and minor versions must match your cluster. For example if you are running a 1.16 EKS
-  cluster set version to v1.16.5. For more details
-  check [documentation](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/autoscaling.md#notes)
+* The cluster autoscaler major and minor versions must match your cluster.
+For example if you are running a 1.16 EKS cluster set version to v1.16.5.
+For more details check [documentation](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/autoscaling.md#notes)
 
 ## Windows users
 
-This module is designed for Linux/Unix development/usage only. If you need to develop from Windows you can use the
-included [devcontainer setup for VScode](https://code.visualstudio.com/docs/remote/containers-tutorial) and run the
-examples the same way but then from then ```examples/basic_flow_devcontainer``` folder
-or ```examples/create_in_existing_subnets_devcontainer```.
+This module is designed for Linux/Unix development/usage only. If you need to develop from Windows you can use the included [devcontainer setup for VScode](https://code.visualstudio.com/docs/remote/containers-tutorial) and run the examples the same way but then from then ```examples/basic_flow_devcontainer``` folder or ```examples/create_in_existing_subnets_devcontainer```.
 
 ## Module dependencies
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Prior to run integration tests specify environment variables:
 
 ### Optional environment variables
 
-- M_NAME_PREFIX - prefix to create AWS resources with
+- M_NAME - prefix to create AWS resources with
 - M_REGION - AWS region to create resources in
 
 and after that run shell command:

--- a/integration_test.go
+++ b/integration_test.go
@@ -319,8 +319,8 @@ func TestPlan(t *testing.T) {
 	k8sVolPath := os.Getenv("K8S_VOL_PATH")
 	sharedPath := setupOutput(t, "plan")
 	relativeSharedPath := sharedPath
-	region := getEnv(t, "M_REGION", defaultRegion)
-	moduleName := getEnv(t, "M_NAME", defaultModuleName)
+	region := getEnv("M_REGION", defaultRegion)
+	moduleName := getEnv("M_NAME", defaultModuleName)
 
 	if len(k8sHostPath) != 0 && len(k8sVolPath) != 0 {
 		sharedPath = path.Join(k8sHostPath, "awsks-plan")
@@ -403,8 +403,8 @@ func TestApply(t *testing.T) {
 	k8sVolPath := os.Getenv("K8S_VOL_PATH")
 	sharedPath := setupOutput(t, "apply")
 	relativeSharedPath := sharedPath
-	region := getEnv(t, "M_REGION", defaultRegion)
-	moduleName := getEnv(t, "M_NAME", defaultModuleName)
+	region := getEnv("M_REGION", defaultRegion)
+	moduleName := getEnv("M_NAME", defaultModuleName)
 
 	if len(k8sHostPath) != 0 && len(k8sVolPath) != 0 {
 		sharedPath = path.Join(k8sHostPath, "awsks-apply")
@@ -655,7 +655,7 @@ func getImageTags(t *testing.T) (awsbiImageTag, awsksImageTag string) {
 	return
 }
 
-func getEnv(t *testing.T, envName, defaultValue string) (envValue string) {
+func getEnv(envName, defaultValue string) (envValue string) {
 	envValue, exists := os.LookupEnv(envName)
 	if !exists {
 		envValue = defaultValue

--- a/integration_test.go
+++ b/integration_test.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	moduleName    = "eks-module"
-	retries       = 30
+	defaultModuleName = "eks-module"
+	defaultRegion     = "eu-central-1"
+	retries           = 30
 )
 
 func TestInit(t *testing.T) {
@@ -52,7 +53,7 @@ func TestInit(t *testing.T) {
 			initParams:    nil,
 			stateLocation: "state.yml",
 			stateContent:  ``,
-			wantOutput: `
+			wantOutput: fmt.Sprintf(`
 #AWSKS | setup | ensure required directories
 #AWSKS | ensure-state-file | checks if state file exists
 #AWSKS | template-config-file | will template config file (and backup previous if exists)
@@ -63,7 +64,7 @@ kind: awsks-config
 awsks:
   name: epiphany
   vpc_id: unset
-  region: eu-central-1
+  region: %s
   subnet_ids: null
   private_route_table_id: unset
   disk_size: 32
@@ -75,15 +76,15 @@ awsks:
       instance_type: t2.small
       asg_desired_capacity: 1
       asg_min_size: 1
-      asg_max_size: 1 
-`,
+      asg_max_size: 1
+`, defaultRegion),
 			wantConfigLocation: "awsks/awsks-config.yml",
-			wantConfigContent: `
+			wantConfigContent: fmt.Sprintf(`
 kind: awsks-config
 awsks:
   name: epiphany
   vpc_id: unset
-  region: eu-central-1
+  region: %s
   subnet_ids: null
   private_route_table_id: unset
   disk_size: 32
@@ -95,8 +96,8 @@ awsks:
       instance_type: t2.small
       asg_desired_capacity: 1
       asg_min_size: 1
-      asg_max_size: 1 
-`,
+      asg_max_size: 1
+`, defaultRegion),
 			wantStateContent: `
 kind: state
 awsks:
@@ -131,7 +132,7 @@ awsks:
       instance_type: t2.small
       asg_desired_capacity: 1
       asg_min_size: 1
-      asg_max_size: 1 
+      asg_max_size: 1
 `,
 			wantConfigLocation: "awsks/awsks-config.yml",
 			wantConfigContent: `
@@ -151,7 +152,7 @@ awsks:
       instance_type: t2.small
       asg_desired_capacity: 1
       asg_min_size: 1
-      asg_max_size: 1 
+      asg_max_size: 1
 `,
 			wantStateContent: `
 kind: state
@@ -163,13 +164,13 @@ awsks:
 			name:          "init with state",
 			initParams:    nil,
 			stateLocation: "state.yml",
-			stateContent: `
+			stateContent: fmt.Sprintf(`
 kind: state
 awsbi:
   status: applied
   name: epiphany
   instance_count: 0
-  region: eu-central-1
+  region: %s
   use_public_ip: false
   force_nat_gateway: true
   rsa_pub_path: "/shared/vms_rsa.pub"
@@ -178,8 +179,8 @@ awsbi:
     public_ip.value: []
     public_subnet_id.value: subnet-0137cf1e7921c1551
     vpc_id.value: vpc-0baa2c4e9e48e608c
-`,
-			wantOutput: `
+`, defaultRegion),
+			wantOutput: fmt.Sprintf(`
 #AWSKS | setup | ensure required directories
 #AWSKS | ensure-state-file | checks if state file exists
 #AWSKS | template-config-file | will template config file (and backup previous if exists)
@@ -190,7 +191,7 @@ kind: awsks-config
 awsks:
   name: epiphany
   vpc_id: vpc-0baa2c4e9e48e608c
-  region: eu-central-1
+  region: %s
   subnet_ids: null
   private_route_table_id: unset
   disk_size: 32
@@ -202,15 +203,15 @@ awsks:
       instance_type: t2.small
       asg_desired_capacity: 1
       asg_min_size: 1
-      asg_max_size: 1 
-`,
+      asg_max_size: 1
+`, defaultRegion),
 			wantConfigLocation: "awsks/awsks-config.yml",
-			wantConfigContent: `
+			wantConfigContent: fmt.Sprintf(`
 kind: awsks-config
 awsks:
   name: epiphany
   vpc_id: vpc-0baa2c4e9e48e608c
-  region: eu-central-1
+  region: %s
   subnet_ids: null
   private_route_table_id: unset
   disk_size: 32
@@ -222,15 +223,15 @@ awsks:
       instance_type: t2.small
       asg_desired_capacity: 1
       asg_min_size: 1
-      asg_max_size: 1 
-`,
-			wantStateContent: `
+      asg_max_size: 1
+`, defaultRegion),
+			wantStateContent: fmt.Sprintf(`
 kind: state
 awsbi:
   status: applied
   name: epiphany
   instance_count: 0
-  region: eu-central-1
+  region: %s
   use_public_ip: false
   force_nat_gateway: true
   rsa_pub_path: "/shared/vms_rsa.pub"
@@ -241,20 +242,20 @@ awsbi:
     vpc_id.value: vpc-0baa2c4e9e48e608c
 awsks:
   status: initialized
-`,
+`, defaultRegion),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			k8sHostPath        := os.Getenv("K8S_HOST_PATH")
-			k8sVolPath         := os.Getenv("K8S_VOL_PATH")
-			sharedPath         := setupOutput(t, "init")
+			k8sHostPath := os.Getenv("K8S_HOST_PATH")
+			k8sVolPath := os.Getenv("K8S_VOL_PATH")
+			sharedPath := setupOutput(t, "init")
 			relativeSharedPath := sharedPath
 
-			if ( len(k8sHostPath) != 0 && len(k8sVolPath) != 0) {
-				sharedPath         = path.Join(k8sHostPath, "awsks-init")
+			if len(k8sHostPath) != 0 && len(k8sVolPath) != 0 {
+				sharedPath = path.Join(k8sHostPath, "awsks-init")
 				relativeSharedPath = path.Join(k8sVolPath, "awsks-init")
 
 				err := os.MkdirAll(relativeSharedPath, os.ModePerm)
@@ -314,13 +315,15 @@ func TestPlan(t *testing.T) {
 	awsAccessKey, awsSecretKey := getAwsCreds(t)
 	awsbiImageTag, awsksImageTag := getImageTags(t)
 
-	k8sHostPath        := os.Getenv("K8S_HOST_PATH")
-	k8sVolPath         := os.Getenv("K8S_VOL_PATH")
-	sharedPath         := setupOutput(t, "plan")
+	k8sHostPath := os.Getenv("K8S_HOST_PATH")
+	k8sVolPath := os.Getenv("K8S_VOL_PATH")
+	sharedPath := setupOutput(t, "plan")
 	relativeSharedPath := sharedPath
+	region := getEnv(t, "M_REGION", defaultRegion)
+	moduleName := getEnv(t, "M_NAME", defaultModuleName)
 
-	if ( len(k8sHostPath) != 0 && len(k8sVolPath) != 0) {
-		sharedPath         = path.Join(k8sHostPath, "awsks-plan")
+	if len(k8sHostPath) != 0 && len(k8sVolPath) != 0 {
+		sharedPath = path.Join(k8sHostPath, "awsks-plan")
 		relativeSharedPath = path.Join(k8sVolPath, "awsks-plan")
 
 		err := os.MkdirAll(relativeSharedPath, os.ModePerm)
@@ -329,7 +332,7 @@ func TestPlan(t *testing.T) {
 		}
 	}
 
-	setupPlan(t, "plan", sharedPath, relativeSharedPath, awsAccessKey, awsSecretKey, awsbiImageTag, awsksImageTag)
+	setupPlan(t, fmt.Sprintf("%s-plan", moduleName), region, sharedPath, relativeSharedPath, awsAccessKey, awsSecretKey, awsbiImageTag, awsksImageTag)
 
 	tests := []struct {
 		name                   string
@@ -339,7 +342,7 @@ func TestPlan(t *testing.T) {
 	}{
 		{
 			name:                   "plan",
-			initParams:             []string{fmt.Sprintf("M_NAME=%s-%s", moduleName, "plan")},
+			initParams:             []string{fmt.Sprintf("M_NAME=%s-plan", moduleName), fmt.Sprintf("M_REGION=%s", region)},
 			wantPlanOutputLastLine: `Plan: 29 to add, 0 to change, 0 to destroy.`,
 			wantTfPlanLocation:     "awsks/terraform-apply.tfplan",
 		},
@@ -386,7 +389,7 @@ func TestPlan(t *testing.T) {
 		})
 	}
 
-	cleanupPlan(t, "plan", relativeSharedPath, awsAccessKey, awsSecretKey)
+	cleanupPlan(t, fmt.Sprintf("%s-plan", moduleName), region, relativeSharedPath, awsAccessKey, awsSecretKey)
 	cleanupOutput(relativeSharedPath)
 }
 
@@ -396,13 +399,15 @@ func TestApply(t *testing.T) {
 	awsAccessKey, awsSecretKey := getAwsCreds(t)
 	awsbiImageTag, awsksImageTag := getImageTags(t)
 
-	k8sHostPath        := os.Getenv("K8S_HOST_PATH")
-	k8sVolPath         := os.Getenv("K8S_VOL_PATH")
-	sharedPath         := setupOutput(t, "apply")
+	k8sHostPath := os.Getenv("K8S_HOST_PATH")
+	k8sVolPath := os.Getenv("K8S_VOL_PATH")
+	sharedPath := setupOutput(t, "apply")
 	relativeSharedPath := sharedPath
+	region := getEnv(t, "M_REGION", defaultRegion)
+	moduleName := getEnv(t, "M_NAME", defaultModuleName)
 
-	if ( len(k8sHostPath) != 0 && len(k8sVolPath) != 0) {
-		sharedPath         = path.Join(k8sHostPath, "awsks-apply")
+	if len(k8sHostPath) != 0 && len(k8sVolPath) != 0 {
+		sharedPath = path.Join(k8sHostPath, "awsks-apply")
 		relativeSharedPath = path.Join(k8sVolPath, "awsks-apply")
 
 		err := os.MkdirAll(relativeSharedPath, os.ModePerm)
@@ -411,7 +416,7 @@ func TestApply(t *testing.T) {
 		}
 	}
 
-	setupPlan(t, "apply", sharedPath, relativeSharedPath, awsAccessKey, awsSecretKey, awsbiImageTag, awsksImageTag)
+	setupPlan(t, fmt.Sprintf("%s-apply", moduleName), region, sharedPath, relativeSharedPath, awsAccessKey, awsSecretKey, awsbiImageTag, awsksImageTag)
 
 	tests := []struct {
 		name       string
@@ -419,7 +424,7 @@ func TestApply(t *testing.T) {
 	}{
 		{
 			name:       "apply",
-			initParams: []string{fmt.Sprintf("M_NAME=%s-%s", moduleName, "apply")},
+			initParams: []string{fmt.Sprintf("M_NAME=%s-apply", moduleName), fmt.Sprintf("M_REGION=%s", region)},
 		},
 	}
 
@@ -506,12 +511,12 @@ func TestApply(t *testing.T) {
 		})
 	}
 
-	cleanupPlan(t, "apply", relativeSharedPath, awsAccessKey, awsSecretKey)
+	cleanupPlan(t, fmt.Sprintf("%s-apply", moduleName), region, relativeSharedPath, awsAccessKey, awsSecretKey)
 	cleanupOutput(relativeSharedPath)
 }
 
-func setupPlan(t *testing.T, suffix, sharedPath, relativeSharedPath, awsAccessKey, awsSecretKey, awsbiImageTag, awsksImageTag string) {
-	cleanupPlan(t, suffix, relativeSharedPath, awsAccessKey, awsSecretKey)
+func setupPlan(t *testing.T, moduleName, region, sharedPath, relativeSharedPath, awsAccessKey, awsSecretKey, awsbiImageTag, awsksImageTag string) {
+	cleanupPlan(t, moduleName, region, relativeSharedPath, awsAccessKey, awsSecretKey)
 
 	if err := generateRsaKeyPair(relativeSharedPath, "test_vms_rsa"); err != nil {
 		t.Fatalf("wasnt able to create rsa file: %s", err)
@@ -521,7 +526,8 @@ func setupPlan(t *testing.T, suffix, sharedPath, relativeSharedPath, awsAccessKe
 		"init",
 		"M_VMS_COUNT=0",
 		"M_PUBLIC_IPS=false",
-		fmt.Sprintf("M_NAME=%s-%s", moduleName, suffix),
+		fmt.Sprintf("M_NAME=%s", moduleName),
+		fmt.Sprintf("M_REGION=%s", region),
 		"M_VMS_RSA=test_vms_rsa",
 	}
 
@@ -560,8 +566,8 @@ func setupPlan(t *testing.T, suffix, sharedPath, relativeSharedPath, awsAccessKe
 	docker.Run(t, awsbiImageTag, applyOpts)
 }
 
-func cleanupPlan(t *testing.T, suffix, sharedPath, awsAccessKey, awsSecretKey string) {
-	cleanupAWSResources(t, "eu-central-1", fmt.Sprintf("%s-%s", moduleName, suffix), awsAccessKey, awsSecretKey)
+func cleanupPlan(t *testing.T, moduleName, region, sharedPath, awsAccessKey, awsSecretKey string) {
+	cleanupAWSResources(t, region, moduleName, awsAccessKey, awsSecretKey)
 }
 
 func setupOutput(t *testing.T, suffix string) string {
@@ -646,6 +652,14 @@ func getImageTags(t *testing.T) (awsbiImageTag, awsksImageTag string) {
 		t.Fatalf("expected non-empty AWSKS_IMAGE_TAG environment variable")
 	}
 
+	return
+}
+
+func getEnv(t *testing.T, envName, defaultValue string) (envValue string) {
+	envValue, exists := os.LookupEnv(envName)
+	if !exists {
+		envValue = defaultValue
+	}
 	return
 }
 

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -75,7 +75,7 @@ steps:
       AWS_SECRET_KEY: $(AWS_SECRET_KEY)
       AWSKS_IMAGE_TAG: $(REPOSITORY_NAME)/$(IMAGE_NAME):$(MAJOR_VERSION)
       AWSBI_IMAGE_TAG: $(AWSBI_IMAGE_TAG)
-      M_NAME: $(M_NAME_PREFIX)-$(Build.BuildNumber)
+      M_NAME: $(M_NAME_PREFIX)-$(Build.BuildId)
       M_REGION: $(M_REGION)
   - task: CmdLine@2
     displayName: 'Cleanup Local Image'

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -40,7 +40,7 @@ steps:
       targetType: 'inline'
       script: |
         echo "##vso[task.prependpath]/tools/go/1.15.2/x64/bin"
-      failOnStderr: true 
+      failOnStderr: true
   - task: Bash@3
     displayName: 'Set Build Variables'
     inputs:
@@ -75,6 +75,8 @@ steps:
       AWS_SECRET_KEY: $(AWS_SECRET_KEY)
       AWSKS_IMAGE_TAG: $(REPOSITORY_NAME)/$(IMAGE_NAME):$(MAJOR_VERSION)
       AWSBI_IMAGE_TAG: $(AWSBI_IMAGE_TAG)
+      M_NAME: $(M_NAME_PREFIX)-$(Build.BuildNumber)
+      M_REGION: $(M_REGION)
   - task: CmdLine@2
     displayName: 'Cleanup Local Image'
     inputs:


### PR DESCRIPTION
These changes allow to pass module name and AWS region to tests to identify which pipeline created resources are related to and in which region they are created. Task - #41 