### PR TITLE
Fixed key pair removal in tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1078,9 +1078,14 @@ func removeKeyPair(t *testing.T, session *session.Session, filterTagName, filter
 		t.Fatal("Key Pair: Cannot get Key Pair list.", err)
 	}
 
+    if len(describe.KeyPairs) == 0 {
+		t.Logf("There is no  key pairs with the tag %s:%s", filterTagName, filterTagValue)
+		return
+	}
+
 	// Do not remove key pairs if there are several ones with the same tag
 	// Resources created by pipeline tests have unique tag values
-	if len(describe.KeyPairs) != 1 {
+	if len(describe.KeyPairs) > 1 {
 		t.Logf("There are several key pairs with the tag %s:%s that will not be removed", filterTagName, filterTagValue)
 		return
 	}


### PR DESCRIPTION
There is a random string added to key pair name by Terraform configuration in AWSBI module. To fix key pairs removal, tag is used for filtering. Task - #42.